### PR TITLE
Don't override `IntEnum.__str__` method

### DIFF
--- a/bavapi/reference/_int_enum.py
+++ b/bavapi/reference/_int_enum.py
@@ -5,13 +5,17 @@ Read more at <https://peps.python.org/pep-0663/>."""
 # pylint: disable=useless-import-alias
 
 import sys
-from enum import IntEnum as IntEnum
+from enum import IntEnum as _IntEnum
 
 __all__ = ("IntEnum",)
 
 if sys.version_info < (3, 11):
 
-    def _int_enum_str(self: IntEnum) -> str:
-        return str(self.value)
+    class IntEnum(_IntEnum):
+        """Patched IntEnum pre Python 3.11."""
 
-    IntEnum.__str__ = _int_enum_str
+        def __str__(self) -> str:
+            return str(self.value)
+
+else:
+    IntEnum = _IntEnum

--- a/bavapi/sync.py
+++ b/bavapi/sync.py
@@ -1,6 +1,7 @@
-"""Convenience functions to perform queries to the Fount synchronously.
+"""
+Convenience functions to perform queries to the Fount synchronously.
 
-Can be used directly without using `asyncio`.
+Can be used directly without `asyncio`.
 
 Meant for experimentation, Jupyter notebooks, one-off scripts, etc.
 
@@ -332,6 +333,8 @@ async def brandscape_data(
         If `fields` is None, all fields are returned.
     include : str or list[str], optional
         Additional resources to include in API response, by default None
+    metric_keys: str or list[str], optional
+        Key or list of keys for the metrics included in the response, by default None
     stack_data : bool, optional
         Whether to expand nested lists into new dictionaries, by default False
     **kwargs

--- a/tests/reference/test_int_enum.py
+++ b/tests/reference/test_int_enum.py
@@ -1,16 +1,10 @@
 # pylint: disable=missing-class-docstring, missing-module-docstring, missing-function-docstring
 
-import sys
-
-import pytest
-
 from bavapi.reference._int_enum import IntEnum
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 11), reason="not needed after python 3.11")
 def test_int_enum_str():
     class MockRef(IntEnum):
         A = 1
 
     assert str(MockRef.A) == "1"
-    assert MockRef.A.__str__.__name__ == "_int_enum_str"

--- a/type_stubs/nest_asyncio.pyi
+++ b/type_stubs/nest_asyncio.pyi
@@ -1,4 +1,4 @@
-#pylint: disable=missing-module-docstring, missing-function-docstring, unused-argument
+# pylint: disable=missing-module-docstring, missing-function-docstring, unused-argument
 
 import asyncio
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Created a custom `IntEnum` child class to avoid overriding stdlib `IntEnum.__str__`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The original implementation for the "hack" to make `IntEnum.__str__` behave the same across Python versions used to override the `__str__` method.

This new implementation is based on a child `IntEnum` class to avoid overriding the stdlib `IntEnum` class.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with `nox` tests, `mypy` and `pylint`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added the changelog accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
