### PR TITLE
Fix category sectors param typo

### DIFF
--- a/bavapi/client.py
+++ b/bavapi/client.py
@@ -830,7 +830,7 @@ class Client:
     async def categories(
         self,
         name: Optional[str] = None,
-        sector: OptionalListOr[int] = None,
+        sectors: OptionalListOr[int] = None,
         *,
         category_id: Optional[int] = None,
         filters: OptionalFiltersOrMapping[_filters.CategoriesFilters] = None,
@@ -855,7 +855,7 @@ class Client:
         ----------
         name : str, optional
             Search categories by name, default None
-        sector : int or list[int], optional
+        sectors : int or list[int], optional
             Filter categories by sector ID, default None
         category_id : int, optional
             Fount category ID, default None
@@ -905,7 +905,7 @@ class Client:
         filters = _filters.CategoriesFilters.ensure(
             filters,
             name=name,
-            sector=sector,
+            sectors=sectors,
         )
 
         query = Query.ensure(

--- a/bavapi/filters.py
+++ b/bavapi/filters.py
@@ -372,7 +372,7 @@ class CategoriesFilters(FountFilters):
 
     Attributes
     ----------
-    sector : int or list[int], optional
+    sectors : int or list[int], optional
         Fount sector ID or list of sector IDs, default None
 
     Other Parameters
@@ -381,7 +381,7 @@ class CategoriesFilters(FountFilters):
         Request items that have been updated since the specified date, default None
     """
 
-    sector: OptionalListOr[int] = None
+    sectors: OptionalListOr[int] = None
 
 
 class CitiesFilters(FountFilters):

--- a/bavapi/sync.py
+++ b/bavapi/sync.py
@@ -785,7 +785,7 @@ async def brandscape_data(
 async def categories(
     token: str,
     name: Optional[str] = None,
-    sector: OptionalListOr[int] = None,
+    sectors: OptionalListOr[int] = None,
     *,
     category_id: Optional[int] = None,
     filters: OptionalFiltersOrMapping[_filters.CategoriesFilters] = None,
@@ -814,7 +814,7 @@ async def categories(
         WPPBAV Fount API token
     name : str, optional
         Search categories by name, default None
-    sector : int or list[int], optional
+    sectors : int or list[int], optional
         Filter categories by sector ID, default 0
     category_id : int, optional
         Fount category ID, default None
@@ -885,7 +885,7 @@ async def categories(
     ) as client:
         return await client.categories(
             name,
-            sector,
+            sectors,
             category_id=category_id,
             filters=filters,
             fields=fields,

--- a/docs/endpoints/categories.md
+++ b/docs/endpoints/categories.md
@@ -33,7 +33,7 @@ For more information on available filters and functionality, see the Fount docum
 
 These filters are available directly within the function/method:
 
-- Positional filters: `name`, `sector`
+- Positional filters: `name`, `sectors`
 - Keyword filters: `category_id`
 
 For other filters, passing a `CategoriesFilters` instance to the `filters` parameter is required.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,12 @@
 
 ## `1.0`
 
+### `1.0.1` (2024-01-19)
+
+#### Fix
+
+- :bug: Fixed typo in `sectors` (previously spelled `sector`) parameter for `categories` endpoint queries.
+
 ### `1.0.0` (2024-01-04)
 
 #### Feature

--- a/docs/usage/advanced.md
+++ b/docs/usage/advanced.md
@@ -66,7 +66,7 @@ from bavapi import Query
 from bavapi.filters import FountFilters
 
 async with bavapi.Client("TOKEN") as bav:
-    res = bav.raw_query("companies", Query(filters=FountFilters(name="Apple")))
+    res = await bav.raw_query("companies", Query(filters=FountFilters(name="Apple")))
 ```
 
 These functions will return a list of JSON dictionaries, one for each entry retrieved from the Fount:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wpp-bavapi"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
     { name = "Ignacio Maiz Vilches", email = "ignacio.maiz@bavgroup.com" },
 ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -253,7 +253,7 @@ async def test_brandscape_data(
     (
         None,
         Query(
-            filters=filters.CategoriesFilters(sector=1),
+            filters=filters.CategoriesFilters(sectors=1),
             fields="test",
             include=["sector"],
         ),
@@ -263,12 +263,12 @@ async def test_brandscape_data(
 async def test_categories(
     mock_query: mock.AsyncMock, fount: Client, query: Optional[Query]
 ):
-    await fount.categories(sector=1, fields="test", query=query)
+    await fount.categories(sectors=1, fields="test", query=query)
 
     mock_query.assert_awaited_once_with(
         "categories",
         Query(
-            filters=filters.CategoriesFilters(sector=1),
+            filters=filters.CategoriesFilters(sectors=1),
             fields="test",
             include=["sector"],
         ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixed typo with `categories` query parameter `sectors` (incorrectly spelled as `sector` before)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added the changelog accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
